### PR TITLE
Add Page Detection - Analog.js

### DIFF
--- a/src/main/java/com/xrath/plugin/fold/TreeStructureProvider.java
+++ b/src/main/java/com/xrath/plugin/fold/TreeStructureProvider.java
@@ -13,7 +13,7 @@ import java.util.regex.Pattern;
 
 public class TreeStructureProvider implements com.intellij.ide.projectView.TreeStructureProvider {
     private final Pattern namePattern =
-            Pattern.compile("(.*)\\.(component|service|pipe|guard|directive|actions|effects|reducer|selectors|state|resolver)\\.(css|sass|scss|stylus|styl|less|html|svg|haml|pug|spec|stories\\.ts|ts)", Pattern.CASE_INSENSITIVE);
+            Pattern.compile("(.*)\\.(component|service|pipe|guard|directive|actions|effects|reducer|selectors|state|resolver|page)\\.(css|sass|scss|stylus|styl|less|html|svg|haml|pug|spec|stories\\.ts|ts)", Pattern.CASE_INSENSITIVE);
 
     @Override
     public @NotNull Collection<AbstractTreeNode<?>> modify(


### PR DESCRIPTION
Hello,

I'm using the meta framework of angular which is Analog. In it, a new type of component called a page is used. So I added this string in the pattern, so that the extension could take into account the analog pages.